### PR TITLE
Remove awscc resources/providers and replace with new non cc versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ If you're looking to raise an issue with this module, please create a new issue 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | ~> 1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | ~> 1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -76,8 +75,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [awscc_chatbot_slack_channel_configuration.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/chatbot_slack_channel_configuration) | resource |
-| [awscc_iam_role.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/iam_role) | resource |
+| [aws_chatbot_slack_channel_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/chatbot_slack_channel_configuration) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs
@@ -88,7 +87,7 @@ No modules.
 | <a name="input_guardrail_policies"></a> [guardrail\_policies](#input\_guardrail\_policies) | A list of IAM policy ARNs that are applied as channel guardrails | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/ReadOnlyAccess"<br>]</pre> | no |
 | <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | A list of policies arns to attach to the aws chatbot iam role as required | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"<br>]</pre> | no |
 | <a name="input_slack_channel_id"></a> [slack\_channel\_id](#input\_slack\_channel\_id) | The Slack channel ID. Find the channel ID in Slack by right clicking on the channel in the channel list and copying the link. The channel ID is the string at the end of the URL. | `string` | n/a | yes |
-| <a name="input_slack_workspace_id"></a> [slack\_workspace\_id](#input\_slack\_workspace\_id) | The Slack workspace ID. Defaults to Ministry of Justice Slack workspace | `string` | `"T02DYEB3A"` | no |
+| <a name="input_slack_team_id"></a> [slack\_team\_id](#input\_slack\_team\_id) | The Slack workspace ID. Defaults to Ministry of Justice Slack workspace | `string` | `"T02DYEB3A"` | no |
 | <a name="input_sns_topic_arns"></a> [sns\_topic\_arns](#input\_sns\_topic\_arns) | ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -5,19 +5,19 @@
 // NOTE that you need to manually setup the Slack client for each AWS account following these steps: https://docs.aws.amazon.com/chatbot/latest/adminguide/slack-setup.html
 // Once this has been actioned once per account you can subsequently create as many Slack channel configurations as required.
 
-resource "awscc_chatbot_slack_channel_configuration" "this" {
-  configuration_name = "slack-channel-config-${random_string.this.result}"
-  iam_role_arn       = awscc_iam_role.this.arn
-  slack_channel_id   = var.slack_channel_id
-  slack_workspace_id = var.slack_workspace_id
-  sns_topic_arns     = var.sns_topic_arns
-  guardrail_policies = var.guardrail_policies
+resource "aws_chatbot_slack_channel_configuration" "this" {
+  configuration_name    = "slack-channel-config-${random_string.this.result}"
+  iam_role_arn          = aws_iam_role.this.arn
+  slack_channel_id      = var.slack_channel_id
+  slack_team_id         = var.slack_team_id
+  sns_topic_arns        = var.sns_topic_arns
+  guardrail_policy_arns = var.guardrail_policies
 }
 
 // Creates a role for the AWS Chatbot - This defines what actions the Chatbot can perform within Slack.
-resource "awscc_iam_role" "this" {
-  role_name = "chatBot-channel-role-${random_string.this.result}"
-  assume_role_policy_document = jsonencode({
+resource "aws_iam_role" "this" {
+  name = "chatBot-channel-role-${random_string.this.result}"
+  assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "aws_chatbot_slack_channel_arn" {
-  value = aws_chatbot_slack_channel_configuration.this.arn
+  value = aws_chatbot_slack_channel_configuration.this.chat_configuration_arn
 }
 output "aws_chatbot_iam_role" {
   value = aws_iam_role.this.arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,8 @@
 output "aws_chatbot_slack_channel_arn" {
-  value = awscc_chatbot_slack_channel_configuration.this.arn
+  value = aws_chatbot_slack_channel_configuration.this.arn
 }
 output "aws_chatbot_iam_role" {
-  value = awscc_iam_role.this.arn
+  value = aws_iam_role.this.arn
 }
 
 output "random_suffix" {

--- a/test/unit-test/providers.tf
+++ b/test/unit-test/providers.tf
@@ -6,14 +6,6 @@ provider "aws" {
   }
 }
 
-# AWS provider for awscc
-provider "awscc" {
-  region = "eu-west-2"
-  assume_role = {
-    role_arn = "arn:aws:iam::${local.environment_management.account_ids["testing-test"]}:role/MemberInfrastructureAccess"
-  }
-}
-
 # AWS provider for the testing-ci user (testing-test account), to get things from there if required
 provider "aws" {
   alias  = "testing-ci-user"

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -8,10 +8,6 @@ terraform {
       source  = "hashicorp/http"
       version = "~> 3.3"
     }
-    awscc = {
-      version = "~> 1.0"
-      source  = "hashicorp/awscc"
-    }
   }
   required_version = "~> 1.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "slack_channel_id" {
   description = "The Slack channel ID. Find the channel ID in Slack by right clicking on the channel in the channel list and copying the link. The channel ID is the string at the end of the URL."
 }
 
-variable "slack_workspace_id" {
+variable "slack_team_id" {
   type        = string
   default     = "T02DYEB3A" //Defaults to Justice Digital Slack Workspace
   description = "The Slack workspace ID. Defaults to Ministry of Justice Slack workspace"

--- a/versions.tf
+++ b/versions.tf
@@ -4,10 +4,6 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
-    awscc = {
-      version = "~> 1.0"
-      source  = "hashicorp/awscc"
-    }
     random = {
       version = "~> 3.0"
       source  = "hashicorp/random"


### PR DESCRIPTION
Terraform has released proper resources/support for creating chatbot channel configs without the need to use the cloud control (cc) versions (which use cloudformation in the background).


This PR updates to use the newer resources and remove refs to the awscc provider.