### PR TITLE
replace deprecated managed_policy_arns with aws_iam_role_policy_attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,14 @@ resource "aws_iam_role" "this" {
       },
     ]
   })
-  managed_policy_arns = var.managed_policy_arns
 }
+// Attach the AWS managed policies to the IAM role
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = toset(var.managed_policy_arns)
 
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}
 // Create random suffix to ensure resource names are unique
 resource "random_string" "this" {
   upper   = false


### PR DESCRIPTION
Tracked via [9857](https://github.com/ministryofjustice/modernisation-platform/issues/9857).
This PR resolves deprecation warning by removing the use of the deprecated `managed_policy_arns` argument in the `aws_iam_role` resource. It replaces it with the recommended `aws_iam_role_policy_attachment` resource.
