### PR TITLE
Update go-terratest.yml

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: 1.24
+          cache-dependency-path: "**/go.sum"
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ~1.3


### PR DESCRIPTION
Fix cache warning 

```
warning: Run Go Unit Tests
Restore cache failed: Dependencies file is not found in /home/runner/work/modernisation-platform-terraform-aws-chatbot/modernisation-platform-terraform-aws-chatbot. Supported file pattern: go.sum
```